### PR TITLE
Wrap ObjectInt with ObjectCell

### DIFF
--- a/SMObjects.inc
+++ b/SMObjects.inc
@@ -55,6 +55,16 @@ methodmap Object < Handle
 		return SetObjectInt(this, key, value);
 	}
 	
+	public any GetCell(char[] key)
+	{
+		return GetObjectCell(this, key);
+	}
+	
+	public bool SetCell(char[] key, any value)
+	{
+		return SetObjectCell(this, key, value);
+	}
+	
 	public bool GetBool(char[] key)
 	{
 		return GetObjectBool(this, key);

--- a/SMObjects.inc
+++ b/SMObjects.inc
@@ -8,6 +8,16 @@ native int GetObjectInt(Handle obj, char[] key);
 
 native bool SetObjectInt(Handle obj, char[] key, int value);
 
+stock any GetObjectCell(Handle obj, char[] key)
+{
+	return view_as<any>(GetObjectInt(obj, key));
+}
+
+stock bool SetObjectCell(Handle obj, char[] key, any value)
+{
+	return SetObjectInt(obj, key, view_as<int>(value));
+}
+
 native float GetObjectFloat(Handle obj, char[] key);
 
 native bool SetObjectFloat(Handle obj, char[] key, float value);

--- a/SMObjects.inc
+++ b/SMObjects.inc
@@ -8,14 +8,14 @@ native int GetObjectInt(Handle obj, char[] key);
 
 native bool SetObjectInt(Handle obj, char[] key, int value);
 
-stock any GetObjectCell(Handle obj, char[] key)
+stock any GetObjectCell(Handle obj2, char[] key)
 {
-	return view_as<any>(GetObjectInt(obj, key));
+	return view_as<any>(GetObjectInt(obj2, key));
 }
 
-stock bool SetObjectCell(Handle obj, char[] key, any value)
+stock bool SetObjectCell(Handle obj2, char[] key, any value)
 {
-	return SetObjectInt(obj, key, view_as<int>(value));
+	return SetObjectInt(obj2, key, view_as<int>(value));
 }
 
 native float GetObjectFloat(Handle obj, char[] key);

--- a/SMObjects.sp
+++ b/SMObjects.sp
@@ -49,5 +49,10 @@ public Action Command_Read(int client, int args)
 	{
 		PrintToServer("Should be %i: %i", i+1, testArray[i]);
 	}
+	
+	ArrayList list = new ArrayList();
+	obj.SetCell("list", list);
+	
+	delete list;
 	delete obj;
 }


### PR DESCRIPTION
Previously, storing a Handle would require casting the Handle to an Integer every read & write. Now ObjectCell will just wrap ObjectInt doing the casting for them while keeping the back-end intact.

Untested.